### PR TITLE
ci: release workflow auto-creates publish branch

### DIFF
--- a/.github/workflows/reusable-publish-release.yml
+++ b/.github/workflows/reusable-publish-release.yml
@@ -172,12 +172,19 @@ jobs:
           done < "$RUNNER_TEMP/tags.txt"
 
       # Copy the source channel onto the published channel(s), preserving the others, then guard that
-      # every tag the published feed references exists before pushing.
+      # every tag the published feed references exists before pushing. On the first release the publish
+      # branch doesn't exist yet, so seed the worktree from the released commit and let the final push
+      # create it.
       - name: Publish to the publish branch
         run: |
           set -euo pipefail
-          git fetch origin "${{ inputs.publish-branch }}:refs/remotes/origin/${{ inputs.publish-branch }}"
-          git worktree add --detach _publish "origin/${{ inputs.publish-branch }}"
+          if git ls-remote --exit-code --heads origin "${{ inputs.publish-branch }}" >/dev/null 2>&1; then
+            git fetch origin "${{ inputs.publish-branch }}:refs/remotes/origin/${{ inputs.publish-branch }}"
+            git worktree add --detach _publish "origin/${{ inputs.publish-branch }}"
+          else
+            echo "Publish branch '${{ inputs.publish-branch }}' doesn't exist yet — bootstrapping it from the released commit."
+            git worktree add --detach _publish HEAD
+          fi
           rsync -a --delete \
             --exclude '.git' --exclude '_publish' --exclude '_depctrl' \
             --exclude 'ctrf' --exclude 'types' --exclude 'build' \

--- a/README.md
+++ b/README.md
@@ -823,7 +823,7 @@ DependencyControl's own feed URL served from `master` through v0.6.x; from v0.7.
 
 ### Using the workflows in your own package
 
-1. **Set up the branches.** Make your dev branch the default and create a publish branch. In your feed, give each package a single dev channel (its name is the `source-channel` input, default `main`); the release workflow creates the published channels.
+1. **Set up the branches.** Make your dev branch the default. The first release creates the publish branch for you, so you needn't create it by hand. In your feed, give each package a single dev channel (its name is the `source-channel` input, default `main`); the release workflow creates the published channels.
 2. **Add two thin caller workflows** that pin a DependencyControl version and pass your layout. A publish caller (`.github/workflows/release.yml`):
 
    ```yaml


### PR DESCRIPTION
## What

The publish step assumed the publish branch already existed, running `git fetch origin <publish-branch>` and `git worktree add … origin/<publish-branch>` unconditionally. On a repo's first release that branch doesn't exist yet, so the run died with:

```
fatal: couldn't find remote ref publish
```

By then it had already pushed the release commit to the dev branch and created the version tags, leaving a half-finished release.

The step now checks whether the branch exists on the remote first. If it does, behavior is unchanged. If it doesn't, the worktree is seeded from the released commit and the step's existing `git push origin HEAD:<publish-branch>` creates the branch.

Seeding from `HEAD` rather than an empty orphan branch is deliberate: `merge-feed --into _publish/DependencyControl.json` exits non-zero when that file is missing, and the step's `rsync` excludes `DependencyControl.json`, so an orphan branch would fail one step later instead.

## Why it matters beyond this repo

`reusable-publish-release.yml` is the building block third-party package repos call, so every one of them would hit this on their first release. The README's setup step told them to create the branch by hand, which is no longer necessary.

## Testing

Not exercised by a real run. This surfaced while releasing DependencyControl 0.7.0, and that release was unblocked by creating the `publish` branch manually, so the new bootstrap path hasn't run in CI yet. It will first execute on the next package repo that releases without a publish branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
