### PR TITLE
fix: v0.6.x upgrade crash + release-asset/changelog tweaks

### DIFF
--- a/.github/workflows/reusable-publish-release.yml
+++ b/.github/workflows/reusable-publish-release.yml
@@ -218,6 +218,21 @@ jobs:
             git push origin "HEAD:refs/heads/${{ inputs.publish-branch }}"
           fi
 
+      - name: Build the release bundle
+        id: bundle
+        if: ${{ inputs.release-channels != '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/bundle"
+          lua _depctrl/depctrl.lua bundle --out-dir "$RUNNER_TEMP/bundle"
+          zip=$(find "$RUNNER_TEMP/bundle" -maxdepth 1 -name '*.zip' -print -quit)
+          if [ -n "$zip" ]; then
+            echo "Bundled $(basename "$zip")"
+          else
+            echo "::warning::The bundle produced no archive; the release(s) will carry no asset."
+          fi
+          echo "zip=$zip" >> "$GITHUB_OUTPUT"
+
       # Optionally cut a GitHub Release for each requested channel that shipped this run. Notes are
       # rendered from the feed's changelog for the released version; a channel other than the stable
       # one is marked prerelease. An existing release for a tag is left untouched.
@@ -225,6 +240,7 @@ jobs:
         if: ${{ inputs.release-channels != '' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          BUNDLE_ZIP: ${{ steps.bundle.outputs.zip }}
         run: |
           set -euo pipefail
           notes="$RUNNER_TEMP/release-notes.md"
@@ -243,7 +259,7 @@ jobs:
             if gh release view "$tag" >/dev/null 2>&1; then
               echo "· release $tag already exists — leaving it"
             else
-              gh release create "$tag" --title "$tag" --notes-file "$notes" $prerelease
+              gh release create "$tag" --title "$tag" --notes-file "$notes" $prerelease ${BUNDLE_ZIP:+"$BUNDLE_ZIP"}
               echo "· created release $tag $prerelease"
             fi
           done

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -779,14 +779,14 @@
       "url": "http://dkolf.de/dkjson-lua/",
       "channels": {
         "main": {
-          "version": "0.7.0",
-          "released": "2026-07-24",
+          "version": "0.7.1",
+          "released": null,
           "default": true,
           "files": [
             {
               "name": ".moon",
               "url": "@{fileBaseUrl}",
-              "sha1": "D88659A96EC9C7EC7D19ABB2A8192213136F834B"
+              "sha1": "20D35A98AFCE11D67576CB8CE58040C663F23308"
             },
             {
               "name": "/vendor/dkjson.lua",
@@ -811,6 +811,9 @@
         }
       },
       "changelog": {
+        "0.7.1": [
+          "fix: Upgrading from a DependencyControl v0.6.x install no longer fails when dkjson is pulled in as a new dependency; dkjson now skips a self-registration step that breaks pre-0.7.0 loaders."
+        ],
         "0.7.0": [
           "feat: Vendored dkjson v2.10 with a DependencyControl version record and json/dkjson self-registration."
         ]

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -900,7 +900,7 @@
         "0.7.0": [
           "feat: Initial release: extracts LuaCATS annotations from MoonScript sources into LuaLS .d.lua type-definition files, with enum-class synthesis, constructor overloads, cross-module type resolution, and an annotation lint mode.",
           "feat: Renders API documentation straight from the parsed annotations: one markdown page per module with MoonScript and Lua call forms for every method, constructor parameter tables, cross-linked types, enum member tables with per-value descriptions, deprecation notices, and private members omitted (or badged on request). Emits ready-to-serve mkdocs or mdBook site scaffolding.",
-          "feat: Class fields, enum exports, and instance defaults are declared as typed @field annotations on the class, and re-exported local functions resolve to their full signature and documentation, so both IntelliSense and generated docs show real types instead of placeholders."
+          "feat: Class fields, enum exports, and instance defaults are declared as typed `@field` annotations on the class, and re-exported local functions resolve to their full signature and documentation, so both IntelliSense and generated docs show real types instead of placeholders."
         ]
       }
     }

--- a/modules/l0/dkjson.moon
+++ b/modules/l0/dkjson.moon
@@ -175,7 +175,7 @@ wrapper.encode = (value, state) ->
 wrapper.__depCtrlInit = (DependencyControl) ->
   wrapper.version = DependencyControl {
     name: "dkjson"
-    version: "0.7.0" -- @{l0.dkjson:version}
+    version: "0.7.1" -- @{l0.dkjson:version}
     description: "David Kolf's JSON module for Lua."
     author: "David Kolf"
     moduleName: "l0.dkjson"
@@ -183,6 +183,8 @@ wrapper.__depCtrlInit = (DependencyControl) ->
     feed: "https://raw.githubusercontent.com/TypesettingTools/DependencyControl/publish/DependencyControl.json"
     provides: {"json", "dkjson"}
   }
-  wrapper.version\register wrapper
+  -- prevent update failure when coming from DependencyControl v0.6.x, which breaks when modules register
+  -- themselves from the initializer hook by checking for presence of a field that only exists in v0.7.0+.
+  wrapper.version\register wrapper if wrapper.version.semanticVersion
 
 return wrapper


### PR DESCRIPTION
Fixes the v0.6.x → v0.7.x self-update crash: dkjson's `__depCtrlInit` calls `register`, which a pre-0.7.0 loader can't run (it indexes a nil ref for a hook-created record). The call is now gated on `semanticVersion`, present only on 0.7.0+ records.

Also folds in two release-workflow fixes: the bundle is built and attached as a release asset, and a bare `@field` in the changelog is backticked so the release page stops listing the GitHub user "field" as a contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)