### PR TITLE
Advertise the Yutils feed in knownFeeds

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -35,6 +35,7 @@
     "phoscity-scripts": "https://raw.githubusercontent.com/PhosCity/Aegisub-Scripts/main/DependencyControl.json",
     "SubInspector": "https://raw.githubusercontent.com/TypesettingTools/SubInspector/master/DependencyControl.json",
     "unanimated-scripts": "https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json",
+    "Yutils": "https://raw.githubusercontent.com/TypesettingTools/Yutils/master/DependencyControl.json",
     "zahuczky-scripts": "https://raw.githubusercontent.com/Zahuczky/Zahuczkys-Aegisub-Scripts/main/DependencyControl.json",
     "zeref-scripts": "https://raw.githubusercontent.com/TypesettingTools/zeref-Aegisub-Scripts/main/DependencyControl.json"
   },


### PR DESCRIPTION
Advertises the Yutils feed added in TypesettingTools/Yutils#2, so DependencyControl officially trusts it.

Yutils has been distributed by bundling it with the Aegisub installer, because no feed offered it. TypesettingTools/Yutils#2 adds one, packaging the library as `tstools.Yutils` and declaring the bare `Yutils` name in `provides`.

Listing that feed in `knownFeeds` folds it into the officially trusted set, which is all it takes for ASSFoundation's existing requirement — `{"moduleName": "Yutils", "optional": true}`, bare and feed-less — to resolve to it through the `provides` alias. **ASSFoundation needs no change.**

The indirection is deliberate. Putting the feed URL directly into ASSFoundation's feed would expose a 0.4.0 feed to v0.6.x clients, which can't parse it — the same format-compatibility trap we just dug out of. Advertising it here means the URL only ever appears in feeds that v0.7.0+ clients read; the retired `master` feed is left untouched, so v0.6.x never learns it exists.

**Merge order:** land TypesettingTools/Yutils#2 and push its `v1.0.0` tag before this change is published to the `publish` branch. Otherwise DependencyControl advertises a feed URL that 404s — not fatal, since feed discovery tolerates unloadable feeds and the ASSFoundation requirement is optional, but it causes pointless failed fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
