### PR TITLE
fix(Toolbox): don't treat feed section templates as scripts

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -54,19 +54,19 @@
       "url": "@{baseUrl}#@{namespace}",
       "channels": {
         "main": {
-          "version": "0.7.0",
-          "released": "2026-07-24",
+          "version": "0.8.1",
+          "released": null,
           "default": true,
           "files": [
             {
               "name": ".moon",
               "url": "@{fileBaseUrl}",
-              "sha1": "ABAB9B3A82C6B47144ED160F484B3617651DDF81"
+              "sha1": "F7B62EAC79C4FBA001B50C12506231C204CC7E80"
             },
             {
               "name": ".moon",
               "url": "@{fileBaseUrl}",
-              "sha1": "59B666472F097BE5D71ADB788A96D7A650830BB5",
+              "sha1": "9329D7020A486DE3F5202963522327AB709FF815",
               "type": "test"
             }
           ],
@@ -105,6 +105,9 @@
           "feat: Added a Global Configuration macro to view and edit DependencyControl's global settings — update behavior, feed discovery and caching, logging, and file paths — in one dialog, so common tweaks no longer need hand-editing the config file. The feed lists stay in the Manage Feeds macro.",
           "change: The Toolbox now updates from a `stable` channel by default; installations on the previous `alpha` channel are migrated automatically.",
           "fix: The Install, Uninstall, and Update script dropdowns now start empty on macOS instead of defaulting to, and being stuck on, their first entry."
+        ],
+        "0.8.1": [
+          "fix: The Install Script macro no longer fails while scanning feeds that set URL templates per section, DependencyControl's own feed among them."
         ]
       }
     }
@@ -117,14 +120,14 @@
       "url": "@{baseUrl}#@{namespace}",
       "channels": {
         "main": {
-          "version": "0.8.0",
-          "released": "2026-07-24",
+          "version": "0.8.1",
+          "released": null,
           "default": true,
           "files": [
             {
               "name": ".moon",
               "url": "@{fileBaseUrl}",
-              "sha1": "EA116FC2F7C3EDA9DC16E603C25669E3ABBA07EA"
+              "sha1": "87CDA007933A971BAEFC91A044CF7FC941535D0D"
             },
             {
               "name": "/Constants.moon",
@@ -250,7 +253,7 @@
             {
               "name": "/ScriptUpdateRecord.moon",
               "url": "@{fileBaseUrl}",
-              "sha1": "56B2C04A436337243E7D294B5C820445A0F733A7"
+              "sha1": "9553BD9771DFEF0E35BA04814E2EAFFA0E27C51A"
             },
             {
               "name": "/SemanticVersion.moon",
@@ -520,7 +523,7 @@
             {
               "name": "/ScriptUpdateRecord.moon",
               "url": "@{fileBaseUrl}",
-              "sha1": "0B66CB43DC28194E93D5CC25426698010FCC436D",
+              "sha1": "287B0C04CC3A4BA92FE30E2258D7EFEA922AFE58",
               "type": "test"
             },
             {
@@ -544,7 +547,7 @@
             {
               "name": "/UpdateFeed.moon",
               "url": "@{fileBaseUrl}",
-              "sha1": "3094DFD9B29DB2F238D8E9986DDB6DEC64BC8D5F",
+              "sha1": "4A3CE78253A52C70D6C28394BF724F9D0552DB0E",
               "type": "test"
             },
             {
@@ -772,6 +775,9 @@
         ],
         "0.8.0": [
           "feat: New `get-version` and `get-current-versions` CLI commands report a feed channel's highest version or its distinct package versions."
+        ],
+        "0.8.1": [
+          "fix: Reading the channel list of a package that declares no channels returns an empty list instead of throwing an error."
         ]
       }
     },

--- a/macros/l0.DependencyControl.Toolbox.moon
+++ b/macros/l0.DependencyControl.Toolbox.moon
@@ -1,6 +1,6 @@
 export script_name = "DependencyControl Toolbox"
 export script_description = "Provides DependencyControl maintenance and configuration tools."
-export script_version = "0.7.0" -- @{l0.DependencyControl.Toolbox:version}
+export script_version = "0.8.1" -- @{l0.DependencyControl.Toolbox:version}
 export script_author = "line0"
 export script_namespace = "l0.DependencyControl.Toolbox"
 
@@ -191,24 +191,24 @@ crawlWithPrompt = (inventory) ->
 install = ->
   config = getConfig!
 
-  addAvailableToInstall = (tbl, feed, scriptType) ->
-    scriptTypeConfigAndFeedKeyName = ScriptTypeSection[scriptType]
 
-    for namespace, data in pairs feed.data[scriptTypeConfigAndFeedKeyName]
+  addAvailableToInstall = (macros, modules, feed) ->
+    for pkg, scriptType, section in feed\walkPackages!
+      namespace = pkg.namespace
       scriptData, err = feed\getScript namespace, scriptType, nil, false
       if err
         logger\warn msgs.install.createScriptUpdateRecordFailed\format terms.scriptType.singular[scriptType], namespace, feed.url, err
         continue
 
+      tbl = scriptType == ScriptType.Module and modules or macros
       channels, defaultChannel = scriptData\getChannels!
       tbl[namespace] or= {}
       for channel in *channels
         record = scriptData.data.channels[channel]
         verNum = DepCtrl.SemanticVersion\toPacked record.version
-        unless config.c[scriptTypeConfigAndFeedKeyName][namespace] or (tbl[namespace][channel] and verNum < tbl[namespace][channel].verNum)
+        unless config.c[section][namespace] or (tbl[namespace][channel] and verNum < tbl[namespace][channel].verNum)
           tbl[namespace][channel] = { name: scriptData.name, version: record.version, verNum: verNum, feed: feed.url,
             default: defaultChannel == channel, moduleName: scriptType == ScriptType.Module and namespace }
-    return tbl
 
   buildDlgList = (tbl) ->
     buildSortedDlgList (add) ->
@@ -229,8 +229,7 @@ install = ->
     continue unless entry.fetched
     feed = DepCtrl.updater.feedLoader\load entry.url
     continue unless feed.data
-    macros = addAvailableToInstall macros, feed, ScriptType.Automation
-    modules = addAvailableToInstall modules, feed, ScriptType.Module
+    addAvailableToInstall macros, modules, feed
 
   moduleList, moduleMap = buildDlgList modules
   macroList, macroMap = buildDlgList macros

--- a/macros/l0.DependencyControl.Toolbox/test.moon
+++ b/macros/l0.DependencyControl.Toolbox/test.moon
@@ -87,8 +87,12 @@ UnitTestSuite "l0.DependencyControl.Toolbox", (macros, dependencies, testExports
     }
     {
       url: "feed://x"
-      data: {macros: {"a.x": true}, modules: {}}
+      data: {macros: {"a.x": {channels: {main: {version: "1.0.0"}}}}, modules: {}}
       getScript: (ns, st) => scriptData, nil
+      -- mirrors UpdateFeed\walkPackages: yields the package (keyed by .namespace), its script type
+      -- and its section, having already skipped the section's non-package template keys
+      walkPackages: => coroutine.wrap ->
+        coroutine.yield {namespace: "a.x"}, domain.ScriptType.Automation, "macros"
     }
 
   {

--- a/modules/l0/DependencyControl.moon
+++ b/modules/l0/DependencyControl.moon
@@ -3,9 +3,9 @@ MIN_MOONSCRIPT_VERSION = "0.3.0"
 SemanticVersion = require "l0.DependencyControl.SemanticVersion"
 moonscript = require 'moonscript.version'
 assert SemanticVersion\check(moonscript.version, MIN_MOONSCRIPT_VERSION),
-  [[ DependencyControl requires Moonscript v%s or later to work, 
+  [[ DependencyControl requires Moonscript v%s or later to work,
 however the Version %s provided by your Aegisub installation is outdated.
-Update to a recent Aegisub build to resolve this issue. 
+Update to a recent Aegisub build to resolve this issue.
 ]]\format MIN_MOONSCRIPT_VERSION, moonscript.version
 
 -- DependencyControl also needs a LuaJIT built with Lua 5.2 compatibility (LUAJIT_ENABLE_LUA52COMPAT):
@@ -108,7 +108,7 @@ Accessors.install DependencyControl
 
 rec = DependencyControl{
   name: "DependencyControl",
-  version: "0.8.0", -- @{l0.DependencyControl:version}
+  version: "0.8.1", -- @{l0.DependencyControl:version}
   description: "Provides script management and auto-updating for Aegisub macros and modules.",
   author: "line0",
   url: "http://github.com/TypesettingTools/DependencyControl",

--- a/modules/l0/DependencyControl/ScriptUpdateRecord.moon
+++ b/modules/l0/DependencyControl/ScriptUpdateRecord.moon
@@ -92,10 +92,11 @@ class ScriptUpdateRecord
 
 
   ---Returns all available channel names for this script and the default channel.
-  ---@return string[] channels
+  ---@return string[] channels Channel names, empty when the package declares none.
   ---@return string? defaultChannel
   getChannels: =>
     channels, default = {}
+    return channels unless type(@data.channels) == "table"
     for name, channel in pairs @data.channels
       channels[#channels+1] = name
       if channel.default and not default

--- a/modules/l0/DependencyControl/test/ScriptUpdateRecord.moon
+++ b/modules/l0/DependencyControl/test/ScriptUpdateRecord.moon
@@ -21,6 +21,13 @@
       _, default = sur\getChannels!
       ut\assertNil default
 
+    -- feeds are third-party input, so a package declaring no channels must not take out its caller
+    getChannels_noChannels: (ut) ->
+      sur = ScriptUpdateRecord "test.NS", {name: "TestScript"}, {c:{}}, domain.ScriptType.Module, false
+      channels, default = sur\getChannels!
+      ut\assertEquals #channels, 0
+      ut\assertNil default
+
     setChannel_valid: (ut) ->
       data = {channels: {release: {default: true, version: "1.0.0", files: {}}, nightly: {version: "2.0.0", files: {}}}, name: "TestScript"}
       sur = ScriptUpdateRecord "test.NS", data, {c:{}}, domain.ScriptType.Module, false
@@ -108,7 +115,7 @@
       ut\assertFalsy result\find "Breaking Changes", 1, true -- breaking is not its own section
 
     _order: {
-      "getChannels_basic", "getChannels_noDefault",
+      "getChannels_basic", "getChannels_noDefault", "getChannels_noChannels",
       "setChannel_valid", "setChannel_invalid",
       "checkPlatform_noConstraint", "checkPlatform_currentPlatform", "checkPlatform_notMatching",
       "getChangelog_noTable", "getChangelog_inRange", "getChangelog_allOutOfRange",

--- a/modules/l0/DependencyControl/test/UpdateFeed.moon
+++ b/modules/l0/DependencyControl/test/UpdateFeed.moon
@@ -961,7 +961,24 @@
       ut\assertEquals decoded.modules["l0.Thing"].channels.release.files[1].url,
         "https://x.test/v1.2.3/modules/l0/Thing.moon"
 
+    -- a section carries the format's section-scoped template keys alongside its packages, so a walk
+    -- must yield only the latter
+    walkPackages_skipsSectionTemplateKeys: (ut) ->
+      feed = stubSelf UpdateFeed, {__class: UpdateFeed, data: {
+        macros: {
+          fileBaseUrls: {script: "https://x.test/@{fileName}"}
+          localFileBasePaths: {script: "@{localFileBasePath}@{fileName}"}
+          "l0.Macro": {channels: {main: {default: true, version: "1.0.0", files: {}}}}
+        }
+        modules: {
+          "l0.Module": {channels: {main: {default: true, version: "2.0.0", files: {}}}}
+        }
+      }}
+      seen = [pkg.namespace for pkg in feed\walkPackages!]
+      ut\assertItemsEqual seen, {"l0.Macro", "l0.Module"}
+
     _order: {
+      "walkPackages_skipsSectionTemplateKeys",
       "knownFeeds_noData", "knownFeeds_withData",
       "getScript_invalidType", "getScript_missing", "getScript_found",
       "getMacro_usesAutomationType", "getModule_usesModuleType",


### PR DESCRIPTION
The Install Script macro dies while scanning feeds:

```
bad argument #1 to 'pairs' (table expected, got nil)
```

Install discovery iterated a feed section's keys directly, so the format's section-scoped template keys (`fileBaseUrls`, `localFileBasePaths`) were handed to `getScript`, which builds a record from any table it gets. Reading that record's channels then raised. It affects any feed that sets URL templates per section — DependencyControl's own among them, so the macro is broken for everyone on 0.8.0.

Discovery now walks the feed's packages, which already skips the non-package keys, and `getChannels` returns an empty list for a package that declares none, so a single malformed entry can't take down a whole scan.

Regression tests for both. `walkPackages` had none of its own despite being the canonical package filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
